### PR TITLE
MANTA-4729 Provide alternative log rotation functions for manta services

### DIFF
--- a/logrotateandupload.sh
+++ b/logrotateandupload.sh
@@ -171,7 +171,7 @@ echo "log rotation complete"
 # minutes and then proceed with uploading the log files.
 sleepsecs=$((RANDOM % 600))
 echo "delaying log upload for $sleepsecs seconds"
-sleep $(($sleepsecs))
+sleep $sleepsecs
 
 
 # Files look like this:

--- a/logrotateandupload.sh
+++ b/logrotateandupload.sh
@@ -204,7 +204,6 @@ do
     if [[ ! -z "$instance" ]]; then
         instance=".$instance"
     fi
-    time=$(date -d \@$(( $(date -d $logtime "+%s") - 3600 )) "+%Y/%m/%d/%H")
     key="/logs/$service/$time/$zone$instance.log"
     mkdirp $service $time
     manta_put "$key" "$LOG_TYPE" "-T $f"

--- a/logrotateandupload.sh
+++ b/logrotateandupload.sh
@@ -180,6 +180,7 @@ sleep $(($sleeptime * 60))
 # or this:
 #     boray_b3a7f519-1096-4e47-9a56-efbd1ab8b692_2012-10-17T21:00:00.log
 # And we transform them to this in manta:
+#     /poseidon/stor/logs/${SERVICE}/${HOURDIR}/${SHORTNODENAME}[.${INSTANCE}].log
 #     /poseidon/stor/logs/buckets-api/2012/10/17/20/0db94777.8081.log
 #     /poseidon/stor/logs/boray/2012/10/17/20/b3a7f519.log
 

--- a/logrotateandupload.sh
+++ b/logrotateandupload.sh
@@ -175,6 +175,7 @@ sleep $(($sleeptime * 60))
 
 
 # Files look like this:
+#     ${SERVICE}_${NODENAME}_${TIMESTAMP}[_${INSTANCE}].log
 #     buckets-api_0db94777-555d-4f1a-a87f-b1e2ee13c025_2012-10-17T21:00:00_8081.log
 # or this:
 #     boray_b3a7f519-1096-4e47-9a56-efbd1ab8b692_2012-10-17T21:00:00.log

--- a/logrotateandupload.sh
+++ b/logrotateandupload.sh
@@ -175,9 +175,12 @@ sleep $(($sleeptime * 60))
 
 
 # Files look like this:
-#     buckets-api_0db94777-555d-4f1a-a87f-b1e2ee13c025_8081_2012-10-17T21:00:00.log
+#     buckets-api_0db94777-555d-4f1a-a87f-b1e2ee13c025_2012-10-17T21:00:00_8081.log
+# or this:
+#     boray_b3a7f519-1096-4e47-9a56-efbd1ab8b692_2012-10-17T21:00:00.log
 # And we transform them to this in manta:
 #     /poseidon/stor/logs/buckets-api/2012/10/17/20/0db94777.8081.log
+#     /poseidon/stor/logs/boray/2012/10/17/20/b3a7f519.log
 
 # Do not run if this script is being run already
 if ! create_lockfile $LOCKFILE; then
@@ -207,4 +210,4 @@ echo "log file upload complete"
 
 # Remove lockfile only if everything succeeded, otherwise it will get cleaned
 # up as a stale pid on a following run
-/usr/bin/rm -f "$LOCKFILE.lock"
+/usr/bin/rm -f "$LOCKFILE"

--- a/logupload.sh
+++ b/logupload.sh
@@ -186,7 +186,7 @@ if ! create_lockfile $BACKUP_LOCKFILE; then
     fail "backup is already running on pid: $RPID"
 fi
 
-log "beginning log file upload"
+echo "beginning log file upload"
 for f in $(ls /var/log/manta/upload/*.log)
 do
     service=$(echo $f | cut -d _ -f 1 | cut -d / -f 6)

--- a/logupload.sh
+++ b/logupload.sh
@@ -191,7 +191,7 @@ for f in $(ls /var/log/manta/upload/*.log)
 do
     service=$(echo $f | cut -d _ -f 1 | cut -d / -f 6)
     zone=$(echo $f | cut -d _ -f 2 | cut -d - -f 1)
-    logtime=$(echo $f | cut -d _ -f 3)
+    logtime=$(echo $f | cut -d _ -f 3 | sed 's|.log||')
     instance=$(echo $f | cut -d _ -f 4 | sed 's|.log||')
     # Not every service will have multiple instances so take that into account
     # when building the upload key

--- a/logupload.sh
+++ b/logupload.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+#
+# Copyright 2019 Joyent, Inc.
+#
+
+#
+# Push /var/log/manta/upload/... log files up to Manta.
+#
+
+echo ""   # blank line in log file helps scroll btwn instances
+set -o errexit
+export PS4='[\D{%FT%TZ}] ${BASHPID}: ${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+set -o xtrace
+
+
+
+## Environment setup
+
+export PATH=/opt/local/bin:$PATH
+
+
+
+## Global variables
+
+# Immutables
+
+SSH_KEY=/root/.ssh/id_rsa
+BACKUP_LOCKFILE=/tmp/backup_lockfile
+
+MANTA_KEY_ID=$(ssh-keygen -l -f $SSH_KEY.pub | awk '{print $2}')
+MANTA_URL=$(json -f /opt/smartdc/common/etc/config.json manta.url)
+MANTA_USER=poseidon
+rejectUnauthorized=$(json -f /opt/smartdc/common/etc/config.json manta.rejectUnauthorized)
+if [[ $rejectUnauthorized = "true" ]]; then
+    MANTA_TLS_INSECURE=0
+else
+    MANTA_TLS_INSECURE=1
+fi
+
+AUTHZ_HEADER="keyId=\"/$MANTA_USER/keys/$MANTA_KEY_ID\",algorithm=\"rsa-sha256\""
+DIR_TYPE='application/json; type=directory'
+LOG_TYPE='text/plain'
+
+# Mutables
+
+NOW=""
+SIGNATURE=""
+
+
+
+## Functions
+
+function log() {
+    echo "$(date --rfc-3339=seconds): $1"
+}
+
+function fail() {
+    echo "$*" >&2
+    exit 1
+}
+
+
+function sign() {
+    NOW=$(date -u "+%a, %d %h %Y %H:%M:%S GMT")
+    SIGNATURE=$(echo "date: $NOW" | tr -d '\n' | openssl dgst -sha256 -sign $SSH_KEY | openssl enc -e -a | tr -d '\n') \
+        || fail "unable to sign data"
+}
+
+
+# $1 -> lockfile to create
+# $$ pid of this script
+function create_lockfile() {
+    # Creating the tempfile can race, but
+    # ln(1) is atomic, so that's the true locking
+    # operation
+    TEMPFILE="$1.$$"
+    LOCKFILE="$1.lock"
+    if ! echo $$ > $TEMPFILE 2>/dev/null; then
+        echo "Unable to write to directory: $(dirname $TEMPFILE)" >&2
+        return 1
+    fi
+
+    # Create lock, remove TEMPFILE
+    #
+    # Use ln(1) to move the temporary file into place because,
+    # unlike mv(1), it will fail if the destination existed
+    # already.
+    if /usr/bin/ln "$TEMPFILE" "$LOCKFILE" 2>/dev/null; then
+        /usr/bin/rm -f "$TEMPFILE"
+        return 0
+    fi
+
+    STALE_PID=$(< $LOCKFILE)
+    if [[ ! "$STALE_PID" -gt "0" ]]; then
+        /usr/bin/rm -f "$TEMPFILE"
+        return 1
+    fi
+
+    # Test if PID from lockfile is running
+    # If it is still running, the function will return here
+    if /usr/bin/kill -0 "$STALE_PID" 2>/dev/null; then
+        /usr/bin/rm -f "$TEMPFILE"
+        return 1
+    fi
+
+    # PID was stale, remove it, then attempt to create lockfile
+    # again
+    if /usr/bin/rm "$LOCKFILE" 2>/dev/null; then
+        echo "Removed stale lock file of process $STALE_PID"
+    fi
+
+    if /usr/bin/ln "$TEMPFILE" "$LOCKFILE" 2>/dev/null; then
+        /usr/bin/rm -f "$TEMPFILE"
+        return 0
+    fi
+
+    # Creating lockfile failed, cleanup and error out
+    /usr/bin/rm -f "$TEMPFILE"
+    return 1
+}
+
+
+function manta_put() {
+    sign || fail "unable to sign"
+    curl -fisSk \
+        -X PUT\
+        -H "Date: $NOW" \
+        -H "Authorization: Signature $AUTHZ_HEADER,signature=\"$SIGNATURE\"" \
+        -H "Connection: close" \
+        -H "Content-Type: $2" \
+        $MANTA_URL/$MANTA_USER/stor$1 $3 || fail "unable to upload $1"
+}
+
+
+# $1 -> service
+# $2 -> YYYY/MM/DD/HH
+function mkdirp() {
+    local year=$(echo $2 | awk -F / '{print $1}')
+    local month=$(echo $2 | awk -F / '{print $2}')
+    local day=$(echo $2 | awk -F / '{print $3}')
+    local hour=$(echo $2 | awk -F / '{print $4}')
+
+    manta_put "/logs" "$DIR_TYPE"
+    manta_put "/logs/$1" "$DIR_TYPE"
+    manta_put "/logs/$1/$year" "$DIR_TYPE"
+    manta_put "/logs/$1/$year/$month" "$DIR_TYPE"
+    manta_put "/logs/$1/$year/$month/$day" "$DIR_TYPE"
+    manta_put "/logs/$1/$year/$month/$day/$hour" "$DIR_TYPE"
+}
+
+
+# Cleanup code
+function finish {
+    # Remove tempfile on exit
+    /usr/bin/rm -f "$BACKUP_LOCKFILE.$$"
+}
+trap finish EXIT
+
+
+## Mainline
+
+# The first step is to kick off logadm to do the file rotation and wait for it
+# to complete.
+log "beginning log rotation"
+/usr/sbin/logadm -v >> /var/log/logadm.log 2>&1
+log "log rotation complete"
+
+# To help avoid a deluge of updates from every manta service immediately at the
+# top of every hour we first sleep for a random time between zero and ten
+# minutes and then proceed with uploading the log files.
+sleeptime=$((RANDOM % 11))
+log "delaying log upload for $sleeptime minutes"
+sleep $(($sleeptime * 60000))
+
+
+# Files look like this:
+#     buckets-api_0db94777-555d-4f1a-a87f-b1e2ee13c025_8081_2012-10-17T21:00:00.log
+# And we transform them to this in manta:
+#     /poseidon/stor/logs/buckets-api/2012/10/17/20/0db94777.8081.log
+
+# Do not run if this script is being run already
+if ! create_lockfile $BACKUP_LOCKFILE; then
+    RPID=$(< $LOCKFILE)
+    fail "backup is already running on pid: $RPID"
+fi
+
+log "beginning log file upload"
+for f in $(ls /var/log/manta/upload/*.log)
+do
+    service=$(echo $f | cut -d _ -f 1 | cut -d / -f 6)
+    zone=$(echo $f | cut -d _ -f 2 | cut -d - -f 1)
+    instance=$(echo $f | cut -d _ -f 3 | cut -d - -f 1)
+    logtime=$(echo $f | cut -d _ -f 4 | sed 's|.log||')
+    time=$(date -d \@$(( $(date -d $logtime "+%s") - 3600 )) "+%Y/%m/%d/%H")
+    key="/logs/$service/$time/$zone.$instance.log"
+    mkdirp $service $time
+    manta_put "$key" "$LOG_TYPE" "-T $f"
+    /usr/bin/rm "$f"
+done
+log "log file upload complete"
+
+# Remove lockfile only if everything succeeded, otherwise it will get cleaned
+# up as a stale pid on a following run
+/usr/bin/rm -f "$BACKUP_LOCKFILE.lock"

--- a/services.sh
+++ b/services.sh
@@ -215,7 +215,7 @@ function manta_setup_common_log_rotation {
 }
 
 #
-# manta_buckets_setup_common_log_rotation [SERVICE]: set up cron to rotate logs,
+# manta_setup_common2_log_rotation [SERVICE]: set up cron to rotate logs,
 # and then configure log rotation for log files common to all Manta zones.  If
 # SERVICE is not specified, then only the truly common logs will be set up.  If
 # SERVICE is given, then logs in /var/svc/log for each instance of SERVICE will
@@ -236,7 +236,7 @@ function manta_setup_common_log_rotation {
 # This function relies on SERVICE already being set up in order to determine the
 # number of instances of SERVICE so it SHOULD NOT be called until after SERVICE
 # has been initialized.
-function manta_buckets_setup_common_log_rotation {
+function manta_setup_common2_log_rotation {
     echo "Setting up common log rotation entries"
 
     #

--- a/services.sh
+++ b/services.sh
@@ -277,8 +277,8 @@ function manta_setup_common2_log_rotation {
     # Add the logadm configurations for the config-agent and registrar services
     # (which are present in every zone), plus the one we've been given.
     #
-    manta_add_logadm_entry "config-agent"
-    manta_add_logadm_entry "registrar"
+    manta_add_logadm_entry2 "config-agent"
+    manta_add_logadm_entry2 "registrar"
     if [[ $# -ge 1 ]]; then
         local logdir="/var/svc/log"
 

--- a/services.sh
+++ b/services.sh
@@ -280,17 +280,19 @@ function manta_setup_common2_log_rotation {
     manta_add_logadm_entry "config-agent"
     manta_add_logadm_entry "registrar"
     if [[ $# -ge 1 ]]; then
+        local logdir="/var/svc/log"
+
         for port in `svcs -H -o fmri $1 | grep -v :default | sed s/'.*-'//`
         do
-            pattern="$logdir/*:$service-$port.log"
+            pattern="$logdir/*:$1-$port.log"
             logadm -w "$1-$port" -C 48 -c -p 1h \
                    -t "/var/log/manta/upload/$1_\$nodename_%Y%m%dT%H%M%S_$port.log" \
                    "$pattern" || fatal "unable to create logadm entry"
         done
 
-        pattern="$logdir/*$service:default.log"
+        pattern="$logdir/*$1:default.log"
         logadm -w "$1" -C 48 -c -p 1h \
-               -t "/var/log/manta/upload/$1_\$nodename_%FT%H:00:00.log" \
+               -t "/var/log/manta/upload/$1_\$nodename_%Y%m%dT%H%M%S.log" \
                "$pattern" || fatal "unable to create logadm entry"
     fi
 

--- a/services.sh
+++ b/services.sh
@@ -282,7 +282,7 @@ function manta_buckets_setup_common_log_rotation {
     manta_add_logadm_entry "config-agent"
     manta_add_logadm_entry "registrar"
     if [[ $# -ge 1 ]]; then
-        for port in `svcs -H -o fmri $1 | grep -v default | sed s/'.*-'//`
+        for port in `svcs -H -o fmri $1 | grep -v :default | sed s/'.*-'//`
         do
             pattern="$logdir/*:$service-$port.log"
             logadm -w "$1-$port" -C 48 -c -p 1h \

--- a/services.sh
+++ b/services.sh
@@ -250,8 +250,6 @@ function manta_buckets_setup_common_log_rotation {
     #
     local DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
     mkdir -p /opt/smartdc/common/sbin
-    cp ${DIR}/backup.sh /opt/smartdc/common/sbin
-    chmod 755 /opt/smartdc/common/sbin/backup.sh
     cp ${DIR}/logrotateandupload.sh /opt/smartdc/common/sbin
     chmod 755 /opt/smartdc/common/sbin/logrotateandupload.sh
     chown root:sys /opt/smartdc/common
@@ -286,7 +284,7 @@ function manta_buckets_setup_common_log_rotation {
         do
             pattern="$logdir/*:$service-$port.log"
             logadm -w "$1-$port" -C 48 -c -p 1h \
-                   -t "/var/log/manta/upload/$1_\$nodename_%FT%H:00:00_$port.log" \
+                   -t "/var/log/manta/upload/$1_\$nodename_%Y%m%dT%H%M%S_$port.log" \
                    "$pattern" || fatal "unable to create logadm entry"
         done
 
@@ -486,13 +484,13 @@ function manta_common_setup {
 }
 
 #
-# manta_buckets_common_setup SERVICE_NAME: entry point invoked by the
+# manta_common2_setup SERVICE_NAME: entry point invoked by the
 # actual setup scripts to trigger setup actions defined in this file.
 # SERVICE_NAME is used for naming log files.  (Note that some programmatic
 # configuration based on the service is hardcoded here, so don't change service
 # names without checking the code below.)
 #
-function manta_buckets_common_setup {
+function manta_common2_setup {
     manta_clear_dns_except_sdc
     manta_download_metadata
     manta_enable_config_agent
@@ -531,10 +529,10 @@ function manta_common_setup_end {
 }
 
 #
-# manta_buckets_common_setup_end: entry point invoked by the actual setup scripts to
+# manta_common2_setup_end: entry point invoked by the actual setup scripts to
 # trigger setup actions that should come after main setup actions.
 #
-function manta_buckets_common_setup_end {
+function manta_common2_setup_end {
     logadm -w log_rotation_upload -C 3 -c -s 1m '/var/log/logrotateandupload.log'
     logadm -w smf_logs -C 3 -c -s 1m '/var/svc/log/*.log'
     logadm -w '/var/log/*.log' -C 2 -c -s 5m

--- a/services.sh
+++ b/services.sh
@@ -252,6 +252,8 @@ function manta_buckets_setup_common_log_rotation {
     mkdir -p /opt/smartdc/common/sbin
     cp ${DIR}/backup.sh /opt/smartdc/common/sbin
     chmod 755 /opt/smartdc/common/sbin/backup.sh
+    cp ${DIR}/logupload.sh /opt/smartdc/common/sbin
+    chmod 755 /opt/smartdc/common/sbin/logupload.sh
     chown root:sys /opt/smartdc/common
 
     #

--- a/services.sh
+++ b/services.sh
@@ -215,7 +215,7 @@ function manta_setup_common_log_rotation {
 }
 
 #
-# manta_setup_common2_log_rotation [SERVICE]: set up cron to rotate logs,
+# manta_common2_setup_log_rotation [SERVICE]: set up cron to rotate logs,
 # and then configure log rotation for log files common to all Manta zones.  If
 # SERVICE is not specified, then only the truly common logs will be set up.  If
 # SERVICE is given, then logs in /var/svc/log for each instance of SERVICE will
@@ -236,7 +236,7 @@ function manta_setup_common_log_rotation {
 # This function relies on SERVICE already being set up in order to determine the
 # number of instances of SERVICE so it SHOULD NOT be called until after SERVICE
 # has been initialized.
-function manta_setup_common2_log_rotation {
+function manta_common2_setup_log_rotation {
     echo "Setting up common log rotation entries"
 
     #

--- a/util.sh
+++ b/util.sh
@@ -83,8 +83,8 @@ function manta_buckets_add_logadm_entry {
     fi
 
     local pattern="$logdir/*$service-$port*.log"
-    logadm -w $1 -C 48 -c -p 1h \
-        -t "/var/log/manta/upload/$1_\$nodename_$2_%FT%H:00:00.log" \
+    logadm -w "$1-$2" -C 48 -c -p 1h \
+        -t "/var/log/manta/upload/$1_\$nodename_%FT%H:00:00_$2.log" \
         "$pattern" || fatal "unable to create logadm entry"
 }
 

--- a/util.sh
+++ b/util.sh
@@ -82,6 +82,7 @@ function manta_buckets_add_logadm_entry {
         logdir="$3"
     fi
 
+    local pattern="$logdir/*$service-$port*.log"
     logadm -w $1 -C 48 -c -p 1h \
         -t "/var/log/manta/upload/$service_\$nodename_$port_%FT%H:00:00.log" \
         "$pattern" || fatal "unable to create logadm entry"

--- a/util.sh
+++ b/util.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Copyright (c) 2015, Joyent, Inc.
+# Copyright 2019 Joyent, Inc.
 #
 
 #
@@ -60,31 +60,6 @@ function manta_add_logadm_entry {
     fi
     logadm -w $1 -C 48 -c -p 1h \
         -t "/var/log/manta/upload/$1_\$nodename_%FT%H:00:00.log" \
-        "$pattern" || fatal "unable to create logadm entry"
-}
-
-#
-# manta_buckets_add_logadm_entry SERVICE PORT [LOGDIR]: creates an entry in
-# /etc/logadm.conf for hourly log rotation of smf log files for the specified
-# service instance in LOGDIR.  Logs are rotated into /var/log/manta and
-# eventually uploaded back to Manta.  See services.sh for details on how this
-# works.
-#
-# If LOGDIR is not specified, it defaults to /var/svc/log.
-#
-function manta_buckets_add_logadm_entry {
-    [[ $# -ge 2 ]] || fatal "manta_buckets_add_logadm_entry requires at least 2 argument"
-
-    local service="$1"
-    local port="$2"
-    local logdir="/var/svc/log"
-    if [[ $# -ge 3 ]]; then
-        logdir="$3"
-    fi
-
-    local pattern="$logdir/*$service-$port*.log"
-    logadm -w "$1-$2" -C 48 -c -p 1h \
-        -t "/var/log/manta/upload/$1_\$nodename_%FT%H:00:00_$2.log" \
         "$pattern" || fatal "unable to create logadm entry"
 }
 

--- a/util.sh
+++ b/util.sh
@@ -84,7 +84,7 @@ function manta_buckets_add_logadm_entry {
 
     local pattern="$logdir/*$service-$port*.log"
     logadm -w $1 -C 48 -c -p 1h \
-        -t "/var/log/manta/upload/$service_\$nodename_$port_%FT%H:00:00.log" \
+        -t "/var/log/manta/upload/$1_\$nodename_$2_%FT%H:00:00.log" \
         "$pattern" || fatal "unable to create logadm entry"
 }
 


### PR DESCRIPTION
This is part of the work described by [RFD 142](https://github.com/joyent/rfd/blob/master/rfd/0142/README.md). It provides a path for manta services that run multiple instances per zone to use SMF logging rather than syslog logging and ensure those logs are properly rotated and uploaded.

There is a new `logupload.sh` script that is used to manage the entire log rotation and upload process. This is one of the goals set out in the RFD. It also introduces some randomness to the timing of the log file upload process. We currently have the problem that all manta services upload log files immediately after rotating the  files at the top of each hour. This had been observed to impact the manta service and the hope is the random wait time used by the `logupload.sh` script will stagger the uploads and diminish the impact.

### Testing

I have been testing this indirectly via the changes to incorporate this work into [`manta-buckets-api`](https://github.com/joyent/manta-buckets-api/tree/MANTA-1936). I have verified that the `logadm` configuration is correct as well as the `crontab` entries. I have also observed the log rotation and upload process and verified it is working as expected for both the `bucket-api` log files and the other service log files in the zone such as `config-agent` and `registrar`.