### PR TITLE
MANTA-5458 - want longer log upload splay time

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -159,6 +159,11 @@ function finish {
 trap finish EXIT
 
 
+# add splay sleep of 30 minutes - SREM-207
+sleepsecs=$((RANDOM % 1800))
+echo "delaying log upload for $sleepsecs seconds"
+sleep $sleepsecs
+
 ## Mainline
 
 # Files look like this:

--- a/backup.sh
+++ b/backup.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Copyright (c) 2017, Joyent, Inc.
+# Copyright (c) 2020, Joyent, Inc.
 #
 
 #
@@ -159,7 +159,9 @@ function finish {
 trap finish EXIT
 
 
-# add splay sleep time of 30 minutes
+# To help avoid a deluge of updates from every manta service immediately at the
+# top of every hour we first sleep for a random time between zero and thirty
+# minutes and then proceed with uploading the log files.
 sleepsecs=$((RANDOM % 1800))
 echo "delaying log upload for $sleepsecs seconds"
 sleep $sleepsecs

--- a/backup.sh
+++ b/backup.sh
@@ -159,7 +159,7 @@ function finish {
 trap finish EXIT
 
 
-# add splay sleep of 30 minutes - SREM-207
+# add splay sleep time of 30 minutes
 sleepsecs=$((RANDOM % 1800))
 echo "delaying log upload for $sleepsecs seconds"
 sleep $sleepsecs

--- a/logrotateandupload.sh
+++ b/logrotateandupload.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Copyright 2019 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 #
 
 #

--- a/logrotateandupload.sh
+++ b/logrotateandupload.sh
@@ -167,9 +167,8 @@ echo "beginning log rotation"
 echo "log rotation complete"
 
 # To help avoid a deluge of updates from every manta service immediately at the
-# top of every hour we first sleep for a random time between zero and ten
+# top of every hour we first sleep for a random time between zero and thirty
 # minutes and then proceed with uploading the log files.
-# add splay sleep time of 30 minutes 
 sleepsecs=$((RANDOM % 1800))
 echo "delaying log upload for $sleepsecs seconds"
 sleep $sleepsecs

--- a/logrotateandupload.sh
+++ b/logrotateandupload.sh
@@ -169,7 +169,8 @@ echo "log rotation complete"
 # To help avoid a deluge of updates from every manta service immediately at the
 # top of every hour we first sleep for a random time between zero and ten
 # minutes and then proceed with uploading the log files.
-sleepsecs=$((RANDOM % 600))
+# add splay sleep of 30 minutes - SREM-207
+sleepsecs=$((RANDOM % 1800))
 echo "delaying log upload for $sleepsecs seconds"
 sleep $sleepsecs
 

--- a/logrotateandupload.sh
+++ b/logrotateandupload.sh
@@ -169,7 +169,7 @@ echo "log rotation complete"
 # To help avoid a deluge of updates from every manta service immediately at the
 # top of every hour we first sleep for a random time between zero and ten
 # minutes and then proceed with uploading the log files.
-# add splay sleep of 30 minutes - SREM-207
+# add splay sleep time of 30 minutes 
 sleepsecs=$((RANDOM % 1800))
 echo "delaying log upload for $sleepsecs seconds"
 sleep $sleepsecs


### PR DESCRIPTION
Adds splay time to log uploads of manta component logs.  There are two scripts in use for this amongst various components.